### PR TITLE
Support reading batches from parquet files on Aliyun OSS.

### DIFF
--- a/arrow/build.sh
+++ b/arrow/build.sh
@@ -2,6 +2,10 @@
 
 set -eo pipefail
 
+cd arrow/src
+git apply ../s3_enhancements.patch
+cd -
+
 if [[ ! -d $CACHE_DIR ]]; then
   CACHE_DIR=arrow/cache
 fi

--- a/arrow/s3_enhancements.patch
+++ b/arrow/s3_enhancements.patch
@@ -1,0 +1,120 @@
+commit 0a6ecaa164267004a96f8df14a1ec9bbd2934c93
+Author: yuanman.ym <yuanman.ym@alibaba-inc.com>
+Date:   Thu Dec 2 16:39:40 2021 +0800
+
+    [C++] Allow passing endpoint and addressing style by environment variables.
+
+diff --git a/cpp/src/arrow/filesystem/s3fs.cc b/cpp/src/arrow/filesystem/s3fs.cc
+index cee0564..2779356 100644
+--- a/cpp/src/arrow/filesystem/s3fs.cc
++++ b/cpp/src/arrow/filesystem/s3fs.cc
+@@ -82,6 +82,7 @@
+ #include "arrow/util/atomic_shared_ptr.h"
+ #include "arrow/util/checked_cast.h"
+ #include "arrow/util/future.h"
++#include "arrow/util/io_util.h"
+ #include "arrow/util/key_value_metadata.h"
+ #include "arrow/util/logging.h"
+ #include "arrow/util/optional.h"
+@@ -90,6 +91,7 @@
+ 
+ namespace arrow {
+ 
++using internal::GetEnvVar;
+ using internal::TaskGroup;
+ using internal::Uri;
+ using io::internal::SubmitIO;
+@@ -114,6 +116,12 @@ using internal::ToAwsString;
+ using internal::ToURLEncodedAwsString;
+ 
+ static const char kSep = '/';
++static const char kS3EndpointEnvVar[] = "S3_ENDPOINT";
++static const char kS3UseHttpsEnvVar[] = "S3_USE_HTTPS";
++static const char kS3AddressingStyle[] = "S3_ADDRESSING_STYLE";
++static const char kHttpsPrefix[] = "https://";
++static const char kHttpPrefix[] = "http://";
++static const char kSchemeSep[] = "://";
+ 
+ namespace {
+ 
+@@ -334,6 +342,39 @@ Result<S3Options> S3Options::FromUri(const Uri& uri, std::string* out_path) {
+     options.ConfigureDefaultCredentials();
+   }
+ 
++  auto maybe_endpoint = GetEnvVar(kS3EndpointEnvVar);
++  if (maybe_endpoint.ok()) {
++    std::string endpoint_str = *std::move(maybe_endpoint);
++    if (endpoint_str.find(kSchemeSep) == std::string::npos) {
++      int use_https = 1;
++      auto maybe_use_https = GetEnvVar(kS3UseHttpsEnvVar);
++      if (maybe_use_https.ok()) {
++        try {
++          use_https = std::stoi(*std::move(maybe_use_https));
++        } catch (...) {
++          // stoi throws an exception when it fails, just ignore it.
++        }
++      }
++      if (use_https > 0) {
++        endpoint_str = std::string(kHttpsPrefix) + endpoint_str;
++      } else {
++        endpoint_str = std::string(kHttpPrefix) + endpoint_str;
++      }
++    }
++    Uri endpoint;
++    RETURN_NOT_OK(endpoint.Parse(endpoint_str));
++    options.scheme = endpoint.scheme();
++    options.endpoint_override = endpoint.host();
++    if (!endpoint.port_text().empty()) {
++      options.endpoint_override += ":" + endpoint.port_text();
++    }
++  }
++
++  auto maybe_addressing_style = GetEnvVar(kS3AddressingStyle);
++  if (maybe_addressing_style.ok()) {
++    options.addressing_style = *std::move(maybe_addressing_style);
++  }
++
+   bool region_set = false;
+   for (const auto& kv : options_map) {
+     if (kv.first == "region") {
+@@ -343,6 +384,8 @@ Result<S3Options> S3Options::FromUri(const Uri& uri, std::string* out_path) {
+       options.scheme = kv.second;
+     } else if (kv.first == "endpoint_override") {
+       options.endpoint_override = kv.second;
++    } else if (kv.first == "addressing_style") {
++      options.addressing_style = kv.second;
+     } else {
+       return Status::Invalid("Unexpected query parameter in S3 URI: '", kv.first, "'");
+     }
+@@ -573,7 +616,16 @@ class ClientBuilder {
+       client_config_.caPath = ToAwsString(internal::global_options.tls_ca_dir_path);
+     }
+ 
+-    const bool use_virtual_addressing = options_.endpoint_override.empty();
++    bool use_virtual_addressing = true;
++    if (options_.addressing_style == "virtual") {
++      use_virtual_addressing = true;
++    } else if (options_.addressing_style == "path") {
++      use_virtual_addressing = false;
++    } else if (options_.addressing_style == "auto") {
++      use_virtual_addressing = options_.endpoint_override.empty();
++    } else {
++      return Status::Invalid("Invalid S3 addressing style '", options_.addressing_style, "'");
++    }
+ 
+     /// Set proxy options if provided
+     if (!options_.proxy_options.scheme.empty()) {
+diff --git a/cpp/src/arrow/filesystem/s3fs.h b/cpp/src/arrow/filesystem/s3fs.h
+index 1aad4dd..a276089 100644
+--- a/cpp/src/arrow/filesystem/s3fs.h
++++ b/cpp/src/arrow/filesystem/s3fs.h
+@@ -85,6 +85,9 @@ struct ARROW_EXPORT S3Options {
+   std::string endpoint_override;
+   /// S3 connection transport, default "https"
+   std::string scheme = "https";
++  /// Addressing style which controls if the bucket name is in the hostname
++  /// or part of the URL. Accept values are: path, virtual and auto.
++  std::string addressing_style = "auto";
+ 
+   /// ARN of role to assume
+   std::string role_arn;

--- a/docs/tutorials/data_loading.md
+++ b/docs/tutorials/data_loading.md
@@ -110,6 +110,42 @@ batch = it.get_next()
 ...
 ```
 
+### Read from files on S3/OSS/HDFS
+
+```bash
+export S3_ENDPOINT=oss-cn-shanghai-internal.aliyuncs.com
+export AWS_ACCESS_KEY_ID=my_id
+export AWS_SECRET_ACCESS_KEY=my_secret
+export S3_ADDRESSING_STYLE=virtual
+```
+
+```{eval-rst}
+.. note::
+   See https://docs.w3cub.com/tensorflow~guide/deploy/s3.html for more
+   information.
+.. note::
+   Set `S3_ADDRESSING_STYLE` to `virtual` to support OSS.
+.. note::
+   Set `S3_USE_HTTPS` to `0` to use `http` for S3 endpoint.
+```
+
+```python
+import tensorflow as tf
+import hybridbackend.tensorflow as hb
+ds = hb.data.ParquetDataset(
+    ['s3://path/to/f1.parquet',
+     'oss://path/to/f2.parquet',
+     'hdfs://host:port/path/to/f3.parquet'],
+    batch_size=1024,
+    fields=['a', 'c'])
+ds = ds.apply(hb.data.to_sparse())
+ds = ds.prefetch(4)
+it = tf.data.make_one_shot_iterator(ds)
+batch = it.get_next()
+# {'a': tensora, 'c': tensorc}
+...
+```
+
 ## Performance
 
 In benchmark for reading 20k samples from 200 columns of a Parquet file,


### PR DESCRIPTION
This pull request closes #9 and support environment variables `S3_ENDPOINT` and `S3_ADDRESSING_STYLE`.

- `S3_ENDPOINT`: Endpoint to S3/OSS service
- `S3_ADDRESSING_STYLE`: For Aliyun OSS, this environment variable must be `virtual`