### PR TITLE
[CI] Follow PEP-440 to rename versions.

### DIFF
--- a/.github/workflows/cpu-legacy-nightly.yaml
+++ b/.github/workflows/cpu-legacy-nightly.yaml
@@ -30,7 +30,7 @@ jobs:
         kubectl exec -it ${PODNAME} -- arrow/download.sh ${ARROW_CACHE_URL_PREFIX}
     - name: Build
       run: |-
-        kubectl exec -it ${PODNAME} -- sh -c 'make -j32 HYBRIDBACKEND_WHEEL_ALIAS=-cpu-legacy-nightly HYBRIDBACKEND_WHEEL_BUILD=rc${{ github.run_id }}' && \
+        kubectl exec -it ${PODNAME} -- sh -c 'make -j32 HYBRIDBACKEND_WHEEL_ALIAS=-cpu-legacy-nightly HYBRIDBACKEND_WHEEL_BUILD=+build.${{ github.run_id }}' && \
         kubectl exec -it ${PODNAME} -- cibuild/repair_dist
     - name: Test
       run: |-

--- a/.github/workflows/cpu-legacy-nightly.yaml
+++ b/.github/workflows/cpu-legacy-nightly.yaml
@@ -30,7 +30,7 @@ jobs:
         kubectl exec -it ${PODNAME} -- arrow/download.sh ${ARROW_CACHE_URL_PREFIX}
     - name: Build
       run: |-
-        kubectl exec -it ${PODNAME} -- sh -c 'make -j32 HYBRIDBACKEND_WHEEL_ALIAS=-cpu-legacy-nightly HYBRIDBACKEND_WHEEL_BUILD=+build.${{ github.run_id }}' && \
+        kubectl exec -it ${PODNAME} -- sh -c 'make -j32 HYBRIDBACKEND_WHEEL_ALIAS=-cpu-legacy-nightly HYBRIDBACKEND_WHEEL_BUILD=.dev${{ github.run_id }}' && \
         kubectl exec -it ${PODNAME} -- cibuild/repair_dist
     - name: Test
       run: |-

--- a/.github/workflows/cpu-nightly.yaml
+++ b/.github/workflows/cpu-nightly.yaml
@@ -30,7 +30,7 @@ jobs:
         kubectl exec -it ${PODNAME} -- arrow/download.sh ${ARROW_CACHE_URL_PREFIX}
     - name: Build
       run: |-
-        kubectl exec -it ${PODNAME} -- sh -c 'make -j32 HYBRIDBACKEND_WHEEL_ALIAS=-cpu-nightly HYBRIDBACKEND_WHEEL_BUILD=rc${{ github.run_id }}' && \
+        kubectl exec -it ${PODNAME} -- sh -c 'make -j32 HYBRIDBACKEND_WHEEL_ALIAS=-cpu-nightly HYBRIDBACKEND_WHEEL_BUILD=+build.${{ github.run_id }}' && \
         kubectl exec -it ${PODNAME} -- cibuild/repair_dist
     - name: Test
       run: |-

--- a/.github/workflows/cpu-nightly.yaml
+++ b/.github/workflows/cpu-nightly.yaml
@@ -30,7 +30,7 @@ jobs:
         kubectl exec -it ${PODNAME} -- arrow/download.sh ${ARROW_CACHE_URL_PREFIX}
     - name: Build
       run: |-
-        kubectl exec -it ${PODNAME} -- sh -c 'make -j32 HYBRIDBACKEND_WHEEL_ALIAS=-cpu-nightly HYBRIDBACKEND_WHEEL_BUILD=+build.${{ github.run_id }}' && \
+        kubectl exec -it ${PODNAME} -- sh -c 'make -j32 HYBRIDBACKEND_WHEEL_ALIAS=-cpu-nightly HYBRIDBACKEND_WHEEL_BUILD=.dev${{ github.run_id }}' && \
         kubectl exec -it ${PODNAME} -- cibuild/repair_dist
     - name: Test
       run: |-

--- a/hybridbackend/__init__.py
+++ b/hybridbackend/__init__.py
@@ -20,6 +20,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__version__ = '0.5.2fix1'
+__version__ = '0.5.2.post1'
 __author__ = 'Alibaba Group Holding Limited'
 __copyright__ = '2021 Alibaba Group Holding Limited'


### PR DESCRIPTION
This PR follows [PEP-440](https://www.python.org/dev/peps/pep-0440/) to rename version `0.5.2fix1` to `0.5.2.post1`.