### PR TITLE
[DIST] Implement a hierarchical embedding lookup.

### DIFF
--- a/hybridbackend/tensorflow/graph/optimize_floormod_shuffle.cc
+++ b/hybridbackend/tensorflow/graph/optimize_floormod_shuffle.cc
@@ -1,0 +1,91 @@
+/* Copyright 2021 Alibaba Group Holding Limited. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if HYBRIDBACKEND_TENSORFLOW
+
+#include <vector>
+
+#include "hybridbackend/common/env.h"
+#include "hybridbackend/tensorflow/graph/common/packing.h"
+#include "hybridbackend/tensorflow/graph/common/relocation.h"
+#include "hybridbackend/tensorflow/graph/common/replacing.h"
+#include "hybridbackend/tensorflow/graph/common/rewriting.h"
+#include "hybridbackend/tensorflow/graph/op_optimization.h"
+
+namespace tensorflow {
+namespace hybridbackend {
+
+namespace {
+inline bool FloormodShuffleOptimizationDisabled() {
+  static const bool kFloormodShuffleOptimizationDisabled =
+      ::hybridbackend::EnvVarGetBool(
+          "HB_OP_FLOORMOD_SHUFFLE_OPTIMIZATION_DISABLED", false);
+  return kFloormodShuffleOptimizationDisabled;
+}
+
+inline bool FloormodShufflePackingDisabled() {
+  static const bool kFloormodShufflePackingDisabled =
+      ::hybridbackend::EnvVarGetBool("HB_OP_FLOORMOD_SHUFFLE_PACKING_DISABLED",
+                                     false);
+  return kFloormodShufflePackingDisabled;
+}
+
+}  // namespace
+
+class OptimizeFloormodShuffleReplacingPass : public OpOptimizationPass {
+ public:
+  Status Optimize(Graph* graph, const SessionOptions* options,
+                  const bool disabled) override {
+    if (TF_PREDICT_FALSE(disabled || FloormodShuffleOptimizationDisabled())) {
+      return Status::OK();
+    }
+
+    TF_RETURN_IF_ERROR(Rewrite("FloormodShuffle", "HbFloormodShuffle")
+                           .WithIntAttr("num_partitions", 1)
+                           .In(graph));
+
+    return Status::OK();
+  }
+};
+
+REGISTER_REPLACING_OPTIMIZATION(OptimizeFloormodShuffleReplacingPass);
+
+class OptimizeFloormodShuffleReductionPass : public OpOptimizationPass {
+ public:
+  Status Optimize(Graph* graph, const SessionOptions* options,
+                  const bool disabled) override {
+    if (TF_PREDICT_FALSE(disabled || FloormodShuffleOptimizationDisabled())) {
+      return Status::OK();
+    }
+
+    if (TF_PREDICT_TRUE(!FloormodShufflePackingDisabled())) {
+      TF_RETURN_IF_ERROR(
+          Pack("HbFloormodShuffle", "HbFloormodShuffleN")
+              .WithTypeAttr("T", {DT_INT32, DT_INT64, DT_UINT32, DT_UINT64})
+              .WithIntAttr("num_partitions")
+              .In(graph));
+
+      return Status::OK();
+    }
+
+    return Status::OK();
+  }
+};
+
+REGISTER_REDUCTION_OPTIMIZATION(OptimizeFloormodShuffleReductionPass);
+}  // namespace hybridbackend
+}  // namespace tensorflow
+
+#endif  // HYBRIDBACKEND_TENSORFLOW

--- a/hybridbackend/tensorflow/graph/optimize_partition_by_dual_modulo.cc
+++ b/hybridbackend/tensorflow/graph/optimize_partition_by_dual_modulo.cc
@@ -1,0 +1,108 @@
+/* Copyright 2021 Alibaba Group Holding Limited. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if HYBRIDBACKEND_TENSORFLOW
+
+#include <vector>
+
+#include "hybridbackend/common/env.h"
+#include "hybridbackend/tensorflow/graph/common/packing.h"
+#include "hybridbackend/tensorflow/graph/common/relocation.h"
+#include "hybridbackend/tensorflow/graph/common/replacing.h"
+#include "hybridbackend/tensorflow/graph/common/rewriting.h"
+#include "hybridbackend/tensorflow/graph/op_optimization.h"
+
+namespace tensorflow {
+namespace hybridbackend {
+
+namespace {
+inline bool PartitionByDualModuloOptimizationDisabled() {
+  static const bool kPartitionByDualModuloOptimizationDisabled =
+      ::hybridbackend::EnvVarGetBool(
+          "HB_OP_PARTITION_BY_DUAL_MODULO_OPTIMIZATION_DISABLED", false);
+  return kPartitionByDualModuloOptimizationDisabled;
+}
+
+inline bool PartitionByDualModuloPackingDisabled() {
+  static const bool kPartitionByDualModuloPackingDisabled =
+      ::hybridbackend::EnvVarGetBool(
+          "HB_OP_PARTITION_BY_DUAL_MODULO_PACKING_DISABLED", false);
+  return kPartitionByDualModuloPackingDisabled;
+}
+}  // namespace
+
+class OptimizePartitionByDualModuloReplacingPass : public OpOptimizationPass {
+ public:
+  Status Optimize(Graph* graph, const SessionOptions* options,
+                  const bool disabled) override {
+    if (TF_PREDICT_FALSE(disabled ||
+                         PartitionByDualModuloOptimizationDisabled())) {
+      return Status::OK();
+    }
+
+    TF_RETURN_IF_ERROR(Rewrite("PartitionByDualModuloStageOne",
+                               "HbPartitionByDualModuloStageOne")
+                           .WithIntAttr("num_partitions", 1)
+                           .WithIntAttr("modulus", 1)
+                           .In(graph));
+
+    TF_RETURN_IF_ERROR(Rewrite("PartitionByDualModuloStageTwo",
+                               "HbPartitionByDualModuloStageTwo")
+                           .WithIntAttr("num_partitions", 1)
+                           .WithIntAttr("modulus", 1)
+                           .In(graph));
+
+    return Status::OK();
+  }
+};
+
+REGISTER_REPLACING_OPTIMIZATION(OptimizePartitionByDualModuloReplacingPass);
+
+class OptimizePartitionByDualModuloReductionPass : public OpOptimizationPass {
+ public:
+  Status Optimize(Graph* graph, const SessionOptions* options,
+                  const bool disabled) override {
+    if (TF_PREDICT_FALSE(disabled ||
+                         PartitionByDualModuloOptimizationDisabled())) {
+      return Status::OK();
+    }
+
+    if (TF_PREDICT_TRUE(!PartitionByDualModuloPackingDisabled())) {
+      TF_RETURN_IF_ERROR(
+          Pack("HbPartitionByDualModuloStageOne",
+               "HbPartitionByDualModuloStageOneN")
+              .WithTypeAttr("T", {DT_INT32, DT_INT64, DT_UINT32, DT_UINT64})
+              .WithIntAttr("num_partitions")
+              .WithIntAttr("modulus")
+              .In(graph));
+      TF_RETURN_IF_ERROR(
+          Pack("HbPartitionByDualModuloStageTwo",
+               "HbPartitionByDualModuloStageTwoN")
+              .WithTypeAttr("T", {DT_INT32, DT_INT64, DT_UINT32, DT_UINT64})
+              .WithIntAttr("num_partitions")
+              .WithIntAttr("modulus")
+              .In(graph));
+      return Status::OK();
+    }
+
+    return Status::OK();
+  }
+};
+
+REGISTER_REDUCTION_OPTIMIZATION(OptimizePartitionByDualModuloReductionPass);
+}  // namespace hybridbackend
+}  // namespace tensorflow
+
+#endif  // HYBRIDBACKEND_TENSORFLOW

--- a/hybridbackend/tensorflow/ops/partition_by_dual_modulo/__init__.py
+++ b/hybridbackend/tensorflow/ops/partition_by_dual_modulo/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2021 Alibaba Group Holding Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+r'''lmgd shuffle related classes and functions.
+'''
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function

--- a/hybridbackend/tensorflow/ops/partition_by_dual_modulo/benchmark.py
+++ b/hybridbackend/tensorflow/ops/partition_by_dual_modulo/benchmark.py
@@ -1,0 +1,123 @@
+# Copyright 2021 Alibaba Group Holding Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+r'''Benchmark for partition, lookup and stitch.
+'''
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import os
+from six.moves import xrange  # pylint: disable=redefined-builtin
+
+import tensorflow as tf
+
+import hybridbackend.tensorflow as hb
+
+
+# pylint: disable=missing-docstring
+def shard_lookup(weight_list, ids_list, params, fusion):
+  results = []
+  if fusion == 'disabled':
+    for i, weight in enumerate(weight_list):
+      with tf.name_scope(f'input_{i}'):
+        ids = ids_list[i]
+        ids_shards, idx_shards = hb.floormod_partition(
+          ids, params.num_partitions)
+        embs_shards = [
+          tf.gather(weight, ids_shards[i] % params.bucket_size)
+          for i in xrange(params.num_partitions)]
+        results.append(tf.dynamic_stitch(idx_shards, embs_shards))
+  elif fusion == 'vertical_and_horizontal_stage_one':
+    for i, weight in enumerate(weight_list):
+      with tf.name_scope(f'input_{i}'):
+        ids = ids_list[i]
+        ids, _, idx = hb.partition_by_dual_modulo_stage_one(
+          ids, params.num_partitions, params.modulus)
+        embs = tf.gather(weight, ids % params.bucket_size)
+        results.append(tf.gather(embs, idx))
+  else:
+    for i, weight in enumerate(weight_list):
+      with tf.name_scope(f'input_{i}'):
+        ids = ids_list[i]
+        ids, _, idx = hb.partition_by_dual_modulo_stage_two(
+          ids, params.num_partitions, params.modulus)
+        embs = tf.gather(weight, ids % params.bucket_size)
+        results.append(tf.gather(embs, idx))
+  return results
+
+
+def build_bench_op(params):
+  value_limit = 3 * params.num_columns * params.column_ids
+  with tf.device(params.device):
+    weight_initializer = tf.random_uniform(
+      [params.bucket_size, params.dim_size], 0, 100.0,
+      dtype=tf.float32)
+    weights = [
+      tf.get_variable(
+        f'weight{c}',
+        use_resource=False,
+        dtype=tf.float32,
+        initializer=weight_initializer)
+      for c in xrange(params.num_columns)]
+  input_initializer = tf.random_uniform(
+    [params.column_ids], 0, value_limit, dtype=tf.int32)
+  inputs = [
+    tf.get_variable(
+      f'input{c}',
+      use_resource=False,
+      dtype=tf.int32,
+      initializer=input_initializer)
+    for c in xrange(params.num_columns)]
+  bench_ops = shard_lookup(
+    weights, inputs, params,
+    fusion=params.fusion)
+  bench_ops = [tf.math.reduce_sum(o) for o in bench_ops]
+  step = tf.train.get_or_create_global_step()
+  bench_ops.append(tf.cast(step.assign_add(1), tf.float32))
+  bench_op = tf.math.add_n(bench_ops)
+  return bench_op
+
+
+@hb.function()
+def benchmark(params):
+  bench_op = build_bench_op(params)
+  hooks = [tf.train.StopAtStepHook(params.num_steps)]
+  hooks.append(
+    hb.train.StepStatHook(
+      count=params.column_ids * params.num_columns / 1000000.,
+      unit='Mlookups'))
+  with tf.train.MonitoredTrainingSession('', hooks=hooks) as sess:
+    while not sess.should_stop():
+      sess.run(bench_op)
+
+
+if __name__ == '__main__':
+  os.environ['CUDA_VISIBLE_DEVICES'] = '0'
+  tf.logging.set_verbosity(tf.logging.INFO)
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--device', type=str, default='/gpu:0')
+  parser.add_argument('--column-ids', type=int, default=100000)
+  parser.add_argument('--dim-size', type=int, default=32)
+  parser.add_argument('--bucket-size', type=int, default=10000)
+  parser.add_argument('--num-columns', type=int, default=100)
+  parser.add_argument('--num-partitions', type=int, default=8)
+  parser.add_argument('--modulus', type=int, default=2)
+  parser.add_argument('--num-steps', type=int, default=10)
+  parser.add_argument(
+    '--fusion', type=str, default='vertical_and_horizontal_stage_two')
+  benchmark(parser.parse_args())

--- a/hybridbackend/tensorflow/ops/partition_by_dual_modulo/functors.h
+++ b/hybridbackend/tensorflow/ops/partition_by_dual_modulo/functors.h
@@ -1,0 +1,56 @@
+/* Copyright 2021 Alibaba Group Holding Limited. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef HYBRIDBACKEND_TENSORFLOW_EMBEDDING_PARTITION_BY_DUAL_MODULO_FUNCTORS_H_
+#define HYBRIDBACKEND_TENSORFLOW_EMBEDDING_PARTITION_BY_DUAL_MODULO_FUNCTORS_H_
+
+#if HYBRIDBACKEND_TENSORFLOW
+
+#include <tensorflow/core/framework/tensor.h>
+#include <tensorflow/core/public/version.h>
+
+namespace tensorflow {
+
+class OpKernelContext;
+
+namespace hybridbackend {
+namespace functor {
+
+struct ComputeShardAtStageOne;
+struct ComputeShardAtStageTwo;
+struct ComputeShardOnGpuAtStageOne;
+struct ComputeShardOnGpuAtStageTwo;
+
+template <typename Device, typename T, typename Stage>
+struct PartitionByDualModulo {
+  void operator()(const int32 num_partitions, const int32 modulus,
+                  const Tensor& input, Tensor* output, Tensor* sizes,
+                  Tensor* indices, OpKernelContext* ctx);
+};
+
+template <typename Device, typename T, typename Stage>
+struct PartitionByDualModuloN {
+  void operator()(const int32 num_partitions, const int32 modulus,
+                  const std::vector<Tensor>& inputs,
+                  std::vector<Tensor*>& outputs,
+                  std::vector<Tensor*>& outputs_sizes,
+                  std::vector<Tensor*>& outputs_indices, OpKernelContext* ctx);
+};
+
+}  // namespace functor
+}  // namespace hybridbackend
+}  // namespace tensorflow
+
+#endif  // HYBRIDBACKEND_TENSORFLOW
+#endif  // HYBRIDBACKEND_TENSORFLOW_EMBEDDING_PARTITION_BY_DUAL_MODULO_FUNCTORS_H_

--- a/hybridbackend/tensorflow/ops/partition_by_dual_modulo/ops.py
+++ b/hybridbackend/tensorflow/ops/partition_by_dual_modulo/ops.py
@@ -1,0 +1,145 @@
+# Copyright 2021 Alibaba Group Holding Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+r'''Arithmetic operators for dense and sparse tensors.
+'''
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import tensor_spec
+
+from hybridbackend.tensorflow.framework.view import OperationLike
+
+
+def _partition_by_dual_modulo_stage_one(
+    ids, num_partitions, modulus, name=None):
+  r'''Shuffle IDs using a two-staged
+    (local modulo and global modulo) strategy.
+
+  Args:
+    ids: Input tensor to partition.
+    num_partitions: Number of partitions.
+    modulus: Size of a partition.
+    name: Name of the operator.
+
+
+  Return:
+    output: A tensor with shuffled IDs.
+    sizes: Size of each shard in output.
+    indices: Indices for gathering back.
+  '''
+  if name is None:
+    name = 'partition_by_dual_modulo_stage_one'
+
+  with ops.device(ids.device):
+    with ops.name_scope(name):
+      return (
+        OperationLike('PartitionByDualModuloStageOne')
+        .returns_tensors(
+          tensor_spec.TensorSpec(shape=ids.shape, dtype=ids.dtype),
+          tensor_spec.TensorSpec(shape=[num_partitions], dtype=dtypes.int32),
+          tensor_spec.TensorSpec(shape=ids.shape, dtype=dtypes.int32))
+        .finalize(
+          ids, num_partitions=num_partitions,
+          modulus=modulus,
+          name=name))
+
+
+def partition_by_dual_modulo_stage_one(
+    ids, num_partitions, modulus, name=None):
+  r'''Shuffle IDs using a two-staged
+    (local modulo and global modulo) strategy.
+
+  Args:
+    ids: Input tensor to partition.
+    num_partitions: Number of partitions.
+    modulus: Size of a partition.
+    name: Name of the operator.
+
+
+  Return:
+    output: A tensor with shuffled IDs.
+    sizes: Size of each shard in output.
+    indices: Indices for gathering back.
+  '''
+  if name is None:
+    name = 'partition_by_dual_modulo_stage_one'
+
+  return _partition_by_dual_modulo_stage_one(
+    ids, num_partitions=num_partitions,
+    modulus=modulus, name=name)
+
+
+def _partition_by_dual_modulo_stage_two(
+    ids, num_partitions, modulus, name=None):
+  r'''Shuffle IDs using a two-staged
+    (local modulo and global modulo) strategy.
+
+  Args:
+    ids: Input tensor to partition.
+    num_partitions: Number of partitions.
+    modulus: Size of a partition.
+    name: Name of the operator.
+
+
+  Return:
+    output: A tensor with shuffled IDs.
+    sizes: Size of each shard in output.
+    indices: Indices for gathering back.
+  '''
+  if name is None:
+    name = 'partition_by_dual_modulo_stage_two'
+
+  with ops.device(ids.device):
+    with ops.name_scope(name):
+      return (
+        OperationLike('PartitionByDualModuloStageTwo')
+        .returns_tensors(
+          tensor_spec.TensorSpec(shape=ids.shape, dtype=ids.dtype),
+          tensor_spec.TensorSpec(shape=[num_partitions], dtype=dtypes.int32),
+          tensor_spec.TensorSpec(shape=ids.shape, dtype=dtypes.int32))
+        .finalize(
+          ids, num_partitions=num_partitions,
+          modulus=modulus,
+          name=name))
+
+
+def partition_by_dual_modulo_stage_two(
+    ids, num_partitions, modulus, name=None):
+  r'''Shuffle IDs using a two-staged
+    (local modulo and global modulo) strategy.
+
+  Args:
+    ids: Input tensor to partition.
+    num_partitions: Number of partitions.
+    modulus: Size of a partition.
+    name: Name of the operator.
+
+
+  Return:
+    output: A tensor with shuffled IDs.
+    sizes: Size of each shard in output.
+    indices: Indices for gathering back.
+  '''
+  if name is None:
+    name = 'partition_by_dual_modulo_stage_two'
+
+  return _partition_by_dual_modulo_stage_two(
+    ids, num_partitions=num_partitions,
+    modulus=modulus, name=name)

--- a/hybridbackend/tensorflow/ops/partition_by_dual_modulo/partition_by_dual_modulo_functors.cc
+++ b/hybridbackend/tensorflow/ops/partition_by_dual_modulo/partition_by_dual_modulo_functors.cc
@@ -1,0 +1,139 @@
+/* Copyright 2021 Alibaba Group Holding Limited. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if HYBRIDBACKEND_TENSORFLOW
+
+#define EIGEN_USE_THREADS
+
+#include <limits>
+
+#include <tensorflow/core/framework/op_kernel.h>
+#include <tensorflow/core/framework/register_types.h>
+#include <tensorflow/core/framework/tensor.h>
+#include <tensorflow/core/public/version.h>
+
+#include "hybridbackend/tensorflow/ops/partition_by_dual_modulo/functors.h"
+
+namespace tensorflow {
+
+using CPUDevice = Eigen::ThreadPoolDevice;
+
+namespace hybridbackend {
+
+namespace functor {
+
+struct ComputeShardAtStageOne {
+  template <typename T>
+  T operator()(const T input, const int32 num_partitions, const int32 modulus) {
+    return (input % num_partitions + num_partitions) % num_partitions;
+  }
+};
+
+struct ComputeShardAtStageTwo {
+  template <typename T>
+  T operator()(const T input, const int32 num_partitions, const int32 modulus) {
+    return input / modulus;
+  }
+};
+
+template <typename T, typename ComputeShard>
+struct PartitionByDualModulo<CPUDevice, T, ComputeShard> {
+  void operator()(const int32 num_partitions, const int32 modulus,
+                  const Tensor& input, Tensor* output, Tensor* sizes,
+                  Tensor* indices, OpKernelContext* ctx) {
+    const int32 input_size = input.NumElements();
+    const T* h_input = input.flat<T>().data();
+    T* h_output = output->flat<T>().data();
+    int32* h_sizes = sizes->flat<int32>().data();
+    int32* h_indices = indices->flat<int32>().data();
+
+    std::vector<int32> local_offsets(input_size, 0);
+    std::vector<int32> shard_offsets(num_partitions, 0);
+    std::vector<T> shard_idx(input_size, 0);
+    const int32 pre_mod_size = num_partitions * modulus;
+    ComputeShard compute_shard;
+    for (size_t i = 0; i < input_size; ++i) {
+      const T pre_mod_res =
+          (h_input[i] % pre_mod_size + pre_mod_size) % pre_mod_size;
+      shard_idx[i] = compute_shard(pre_mod_res, num_partitions, modulus);
+    }
+    for (size_t i = 0; i < input_size; ++i) {
+      local_offsets[i] = shard_offsets[shard_idx[i]];
+      shard_offsets[shard_idx[i]]++;
+    }
+    std::memcpy(h_sizes, shard_offsets.data(), num_partitions * sizeof(int32));
+    for (size_t i = 1; i < num_partitions; ++i) {
+      shard_offsets[i] += shard_offsets[i - 1];
+    }
+    for (size_t i = 0; i < input_size; ++i) {
+      const T v = h_input[i];
+      const T shard = shard_idx[i];
+      int32 offset = local_offsets[i];
+      if (shard > 0) {
+        offset += shard_offsets[shard - 1];
+      }
+      h_output[offset] = v;
+      h_indices[i] = offset;
+    }
+  }
+};
+
+template struct PartitionByDualModulo<CPUDevice, int32, ComputeShardAtStageOne>;
+template struct PartitionByDualModulo<CPUDevice, int32, ComputeShardAtStageTwo>;
+template struct PartitionByDualModulo<CPUDevice, int64, ComputeShardAtStageOne>;
+template struct PartitionByDualModulo<CPUDevice, int64, ComputeShardAtStageTwo>;
+template struct PartitionByDualModulo<CPUDevice, uint32,
+                                      ComputeShardAtStageOne>;
+template struct PartitionByDualModulo<CPUDevice, uint32,
+                                      ComputeShardAtStageTwo>;
+template struct PartitionByDualModulo<CPUDevice, uint64,
+                                      ComputeShardAtStageOne>;
+template struct PartitionByDualModulo<CPUDevice, uint64,
+                                      ComputeShardAtStageTwo>;
+
+template <typename T, typename ComputeShard>
+struct PartitionByDualModuloN<CPUDevice, T, ComputeShard> {
+  void operator()(const int32 num_partitions, const int32 modulus,
+                  const std::vector<Tensor>& inputs,
+                  std::vector<Tensor*>& outputs,
+                  std::vector<Tensor*>& outputs_sizes,
+                  std::vector<Tensor*>& outputs_indices, OpKernelContext* ctx) {
+    OP_REQUIRES_OK(ctx, errors::Unimplemented(
+                            "PartitionByDualModuloN on CPU not implemented."));
+  }
+};
+
+template struct PartitionByDualModuloN<CPUDevice, int32,
+                                       ComputeShardAtStageOne>;
+template struct PartitionByDualModuloN<CPUDevice, int32,
+                                       ComputeShardAtStageTwo>;
+template struct PartitionByDualModuloN<CPUDevice, int64,
+                                       ComputeShardAtStageOne>;
+template struct PartitionByDualModuloN<CPUDevice, int64,
+                                       ComputeShardAtStageTwo>;
+template struct PartitionByDualModuloN<CPUDevice, uint32,
+                                       ComputeShardAtStageOne>;
+template struct PartitionByDualModuloN<CPUDevice, uint32,
+                                       ComputeShardAtStageTwo>;
+template struct PartitionByDualModuloN<CPUDevice, uint64,
+                                       ComputeShardAtStageOne>;
+template struct PartitionByDualModuloN<CPUDevice, uint64,
+                                       ComputeShardAtStageTwo>;
+
+}  // namespace functor
+}  // namespace hybridbackend
+}  // namespace tensorflow
+
+#endif  // HYBRIDBACKEND_TENSORFLOW

--- a/hybridbackend/tensorflow/ops/partition_by_dual_modulo/partition_by_dual_modulo_functors.cu.cc
+++ b/hybridbackend/tensorflow/ops/partition_by_dual_modulo/partition_by_dual_modulo_functors.cu.cc
@@ -1,0 +1,421 @@
+/* Copyright 2021 Alibaba Group Holding Limited. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if HYBRIDBACKEND_TENSORFLOW
+
+#if GOOGLE_CUDA
+#define EIGEN_USE_GPU
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <limits>
+
+#include <tensorflow/core/framework/register_types.h>
+#include <tensorflow/core/framework/tensor.h>
+#include <tensorflow/core/public/version.h>
+
+#include "hybridbackend/common/atomic.cu.h"
+#include "hybridbackend/common/profiler.h"
+
+#include "hybridbackend/tensorflow/common/device_functions.h"
+#include "hybridbackend/tensorflow/ops/partition_by_dual_modulo/functors.h"
+
+namespace tensorflow {
+
+using GPUDevice = Eigen::GpuDevice;
+
+namespace hybridbackend {
+
+namespace functor {
+
+struct ComputeShardOnGpuAtStageOne {
+  template <typename T>
+  __host__ __device__ T operator()(const T input, const int32 num_partitions,
+                                   const int32 modulus) {
+    return (input % num_partitions + num_partitions) % num_partitions;
+  }
+};
+
+struct ComputeShardOnGpuAtStageTwo {
+  template <typename T>
+  __host__ __device__ T operator()(const T input, const int32 num_partitions,
+                                   const int32 modulus) {
+    return input / modulus;
+  }
+};
+
+template <typename T, typename ComputeShard>
+__global__ void PartitionComputeSizes(const int32 num_partitions,
+                                      const int32 modulus,
+                                      const int32 input_size, const T* d_input,
+                                      int32* d_sizes, int32* d_offsets) {
+  const int32 pre_mod_size = num_partitions * modulus;
+  for (int32 idx : CudaGridRangeX(input_size)) {
+    const T pre_mod_res =
+        (d_input[idx] % pre_mod_size + pre_mod_size) % pre_mod_size;
+    ComputeShard compute_shard;
+    const T shard = compute_shard(pre_mod_res, num_partitions, modulus);
+    d_offsets[idx] = atomicAdd(d_sizes + shard, 1);
+  }
+}
+
+template <typename T, typename ComputeShard>
+__global__ void PartitionPopulate(const int32 num_partitions,
+                                  const int32 modulus, const int32 input_size,
+                                  const T* d_input, const int32* d_sizes,
+                                  const int32* d_offsets, T* d_output,
+                                  int32* d_indices) {
+  extern __shared__ int32 outputs_offsets[];
+  const int32 pre_mod_size = num_partitions * modulus;
+  if (threadIdx.x == 0) {
+    outputs_offsets[0] = 0;
+    for (int i = 1; i < num_partitions; ++i) {
+      outputs_offsets[i] = outputs_offsets[i - 1] + ldg(d_sizes + i - 1);
+    }
+  }
+  __syncthreads();
+
+  for (int32 idx : CudaGridRangeX(input_size)) {
+    const T v = d_input[idx];
+    const T pre_mod_res = (v % pre_mod_size + pre_mod_size) % pre_mod_size;
+    ComputeShard compute_shard;
+    const T shard = compute_shard(pre_mod_res, num_partitions, modulus);
+
+    const int32 offset = d_offsets[idx] + outputs_offsets[shard];
+    d_output[offset] = v;
+    d_indices[idx] = offset;
+  }
+}
+
+template <typename T, typename ComputeShard>
+struct PartitionByDualModulo<GPUDevice, T, ComputeShard> {
+  void operator()(const int32 num_partitions, const int32 modulus,
+                  const Tensor& input, Tensor* output, Tensor* sizes,
+                  Tensor* indices, OpKernelContext* ctx) {
+    const int32 input_size = input.NumElements();
+    const T* d_input = input.flat<T>().data();
+    T* d_output = output->flat<T>().data();
+    int32* d_sizes = sizes->flat<int32>().data();
+    int32* d_indices = indices->flat<int32>().data();
+
+    auto cu_stream = CudaStream(ctx->op_device_context()->stream());
+    auto stream = *(cu_stream.get());
+    auto d = ctx->eigen_device<GPUDevice>();
+    cu_stream.ThenMemset(d_sizes, 0, num_partitions * sizeof(int32));
+
+    if (TF_PREDICT_FALSE(input_size == 0)) {
+      return;
+    }
+
+    auto* range =
+        ::hybridbackend::ProfilerRange::forSynch("PartitionByDualModulo");
+    Tensor offsets_t;
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_INT32, TensorShape({input_size}),
+                                           &offsets_t));
+    int32* d_offsets = offsets_t.flat<int32>().data();
+
+    CudaLaunch(PartitionComputeSizes<T, ComputeShard>, input_size, 0, d,
+               nullptr, num_partitions, modulus, input_size, d_input, d_sizes,
+               d_offsets);
+    CudaLaunch(PartitionPopulate<T, ComputeShard>, input_size,
+               num_partitions * sizeof(int32), d, nullptr, num_partitions,
+               modulus, input_size, d_input, d_sizes, d_offsets, d_output,
+               d_indices);
+
+    ctx->device()->tensorflow_gpu_device_info()->event_mgr->ThenExecute(
+        ctx->op_device_context()->stream(), [range]() { delete range; });
+  }
+};
+
+template struct PartitionByDualModulo<GPUDevice, int32,
+                                      ComputeShardOnGpuAtStageOne>;
+template struct PartitionByDualModulo<GPUDevice, int32,
+                                      ComputeShardOnGpuAtStageTwo>;
+template struct PartitionByDualModulo<GPUDevice, int64,
+                                      ComputeShardOnGpuAtStageOne>;
+template struct PartitionByDualModulo<GPUDevice, int64,
+                                      ComputeShardOnGpuAtStageTwo>;
+template struct PartitionByDualModulo<GPUDevice, uint32,
+                                      ComputeShardOnGpuAtStageOne>;
+template struct PartitionByDualModulo<GPUDevice, uint32,
+                                      ComputeShardOnGpuAtStageTwo>;
+template struct PartitionByDualModulo<GPUDevice, uint64,
+                                      ComputeShardOnGpuAtStageOne>;
+template struct PartitionByDualModulo<GPUDevice, uint64,
+                                      ComputeShardOnGpuAtStageTwo>;
+
+template <typename T>
+__global__ void PartitionNZeroSizes(const int32 total_num_partitions,
+                                    const int32 num_partitions,
+                                    int32** hd_outputs_sizes) {
+  for (int32 idx : CudaGridRangeX(total_num_partitions)) {
+    const int32 s = idx / num_partitions;
+    const int32 sidx = idx % num_partitions;
+    hd_outputs_sizes[s][sidx] = 0;
+  }
+}
+
+template <typename T, typename ComputeShard>
+__global__ void PartitionNComputeSizes(
+    const int32 total_max_inputs_size, const int32 max_inputs_size,
+    const int32 num_partitions, const int32 modulus, const int32* d_inputs_size,
+    const size_t* dd_inputs, size_t* dd_outputs_sizes,
+    int32* d_output_segment_offsets) {
+  const int32 pre_mod_size = num_partitions * modulus;
+  for (int32 idx : CudaGridRangeX(total_max_inputs_size)) {
+    const int32 s = idx / max_inputs_size;
+    const int32 sidx = idx % max_inputs_size;
+    if (sidx < ldg(d_inputs_size + s)) {
+      const T* d_input = reinterpret_cast<const T*>(ldg(dd_inputs + s));
+      const T pre_mod_res =
+          (d_input[sidx] % pre_mod_size + pre_mod_size) % pre_mod_size;
+      ComputeShard compute_shard;
+      const T shard = compute_shard(pre_mod_res, num_partitions, modulus);
+
+      int32* d_sizes = reinterpret_cast<int32*>(ldg(dd_outputs_sizes + s));
+      d_output_segment_offsets[idx] = atomicAdd(d_sizes + shard, 1);
+    }
+  }
+}
+
+__global__ void PartitionNComputeOffsets(const int32 num_inputs,
+                                         const int32 num_partitions,
+                                         size_t* dd_outputs_sizes,
+                                         int32* d_output_offsets) {
+  for (int32 idx : CudaGridRangeX(num_inputs)) {
+    int32* d_sizes = reinterpret_cast<int32*>(ldg(dd_outputs_sizes + idx));
+    d_output_offsets[num_partitions * idx] = 0;
+    for (int32 p = 1; p < num_partitions; ++p) {
+      d_output_offsets[num_partitions * idx + p] =
+          d_output_offsets[num_partitions * idx + p - 1] + ldg(d_sizes + p - 1);
+    }
+  }
+}
+
+template <typename T, typename ComputeShard>
+__global__ void PartitionNPopulate(
+    const int32 total_max_inputs_size, const int32 max_inputs_size,
+    const int32 num_partitions, const int32 modulus, const int32* d_inputs_size,
+    const size_t* dd_inputs, size_t* dd_outputs, size_t* dd_outputs_indices,
+    int32* d_output_segment_offsets, int32* d_output_offsets) {
+  const int32 pre_mod_size = num_partitions * modulus;
+  for (int32 idx : CudaGridRangeX(total_max_inputs_size)) {
+    const int32 s = idx / max_inputs_size;
+    const int32 sidx = idx % max_inputs_size;
+    if (sidx < ldg(d_inputs_size + s)) {
+      const T* d_input = reinterpret_cast<const T*>(ldg(dd_inputs + s));
+      const T v = d_input[sidx];
+      const T pre_mod_res = (v % pre_mod_size + pre_mod_size) % pre_mod_size;
+      ComputeShard compute_shard;
+      const T shard = compute_shard(pre_mod_res, num_partitions, modulus);
+      const int32 soffset = d_output_segment_offsets[idx] +
+                            ldg(d_output_offsets + num_partitions * s + shard);
+      T* d_output = reinterpret_cast<T*>(ldg(dd_outputs + s));
+      d_output[soffset] = v;
+      int32* d_indices = reinterpret_cast<int32*>(ldg(dd_outputs_indices + s));
+      d_indices[sidx] = soffset;
+    }
+  }
+}
+
+template <typename T, typename ComputeShard>
+struct PartitionByDualModuloN<GPUDevice, T, ComputeShard> {
+  void operator()(const int32 num_partitions, const int32 modulus,
+                  const std::vector<Tensor>& inputs,
+                  std::vector<Tensor*>& outputs,
+                  std::vector<Tensor*>& outputs_sizes,
+                  std::vector<Tensor*>& outputs_indices, OpKernelContext* ctx) {
+    auto* range =
+        ::hybridbackend::ProfilerRange::forSynch("PartitionByDualModuloN");
+    const int32 num_inputs = inputs.size();
+    std::vector<int32> inputs_size;
+    for (int i = 0; i < num_inputs; ++i) {
+      inputs_size.push_back(inputs[i].NumElements());
+    }
+    int32 block_size = 0;
+    int32 min_grid_size = 0;
+    int32 grid_size = 0;
+
+    auto cu_stream = CudaStream(ctx->op_device_context()->stream());
+    auto d = ctx->eigen_device<GPUDevice>();
+
+    AllocatorAttributes host_alloc_attrs;
+    host_alloc_attrs.set_on_host(true);
+    host_alloc_attrs.set_gpu_compatible(true);
+
+    int32 num_nonzero_inputs = 0;
+    for (int32 i = 0; i < num_inputs; ++i) {
+      if (TF_PREDICT_TRUE(inputs_size[i] > 0)) {
+        num_nonzero_inputs++;
+      }
+    }
+
+    Tensor hd_all_outputs_sizes_t;
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_temp(
+                 DT_INT8,
+                 TensorShape({num_inputs * static_cast<int32>(sizeof(int32*))}),
+                 &hd_all_outputs_sizes_t, host_alloc_attrs));
+    int32** hd_all_outputs_sizes =
+        reinterpret_cast<int32**>(hd_all_outputs_sizes_t.flat<int8>().data());
+    for (int32 i = 0; i < num_inputs; ++i) {
+      hd_all_outputs_sizes[i] = outputs_sizes[i]->flat<int32>().data();
+    }
+
+    const int32 total_num_partitions = num_inputs * num_partitions;
+    CudaLaunch(PartitionNZeroSizes<T>, total_num_partitions, 0, d, nullptr,
+               total_num_partitions, num_partitions, hd_all_outputs_sizes);
+
+    if (TF_PREDICT_FALSE(num_nonzero_inputs == 0)) {
+      TensorReference ref_hd_all_outputs_sizes_t(hd_all_outputs_sizes_t);
+      ctx->device()->tensorflow_gpu_device_info()->event_mgr->ThenExecute(
+          ctx->op_device_context()->stream(), [ref_hd_all_outputs_sizes_t]() {
+            ref_hd_all_outputs_sizes_t.Unref();
+          });
+      return;
+    }
+
+    Tensor h_inputs_size_t;
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_temp(DT_INT32, TensorShape({num_nonzero_inputs}),
+                                &h_inputs_size_t, host_alloc_attrs));
+    int32* h_inputs_size = h_inputs_size_t.flat<int32>().data();
+
+    const int32 ptrs_bytes =
+        num_nonzero_inputs * static_cast<int32>(sizeof(T*));
+    Tensor hd_ptrs_t;
+    OP_REQUIRES_OK(ctx,
+                   ctx->allocate_temp(DT_INT8, TensorShape({4 * ptrs_bytes}),
+                                      &hd_ptrs_t, host_alloc_attrs));
+    int8* hd_ptrs = hd_ptrs_t.flat<int8>().data();
+    const T** hd_inputs = reinterpret_cast<const T**>(hd_ptrs);
+    T** hd_outputs = reinterpret_cast<T**>(hd_ptrs + ptrs_bytes);
+    int32** hd_outputs_sizes =
+        reinterpret_cast<int32**>(hd_ptrs + 2 * ptrs_bytes);
+    int32** hd_outputs_indices =
+        reinterpret_cast<int32**>(hd_ptrs + 3 * ptrs_bytes);
+    for (int32 i = 0, j = 0; i < num_inputs; ++i) {
+      if (TF_PREDICT_TRUE(inputs_size[i] > 0)) {
+        h_inputs_size[j] = inputs_size[i];
+        hd_inputs[j] = inputs[i].flat<T>().data();
+        hd_outputs[j] = outputs[i]->flat<T>().data();
+        hd_outputs_sizes[j] = outputs_sizes[i]->flat<int32>().data();
+        hd_outputs_indices[j] = outputs_indices[i]->flat<int32>().data();
+        ++j;
+      }
+    }
+    int32 max_inputs_size = h_inputs_size[0];
+    for (int32 i = 1; i < num_nonzero_inputs; ++i) {
+      if (max_inputs_size < h_inputs_size[i]) {
+        max_inputs_size = h_inputs_size[i];
+      }
+    }
+    const int32 total_max_inputs_size = max_inputs_size * num_nonzero_inputs;
+
+    Tensor d_inputs_size_t;
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_temp(DT_INT32, TensorShape({num_nonzero_inputs}),
+                                &d_inputs_size_t));
+    int32* d_inputs_size = d_inputs_size_t.flat<int32>().data();
+    se::DeviceMemoryBase d_inputs_size_ptr(d_inputs_size,
+                                           d_inputs_size_t.TotalBytes());
+    ctx->op_device_context()->stream()->ThenMemcpy(
+        &d_inputs_size_ptr, h_inputs_size, d_inputs_size_t.TotalBytes());
+
+    Tensor dd_ptrs_t;
+    OP_REQUIRES_OK(
+        ctx,
+        ctx->allocate_temp(DT_INT8, TensorShape({4 * ptrs_bytes}), &dd_ptrs_t));
+    int8* dd_ptrs = dd_ptrs_t.flat<int8>().data();
+    se::DeviceMemoryBase dd_ptrs_ptr(dd_ptrs, dd_ptrs_t.TotalBytes());
+    ctx->op_device_context()->stream()->ThenMemcpy(&dd_ptrs_ptr, hd_ptrs,
+                                                   dd_ptrs_t.TotalBytes());
+    const size_t* dd_inputs = reinterpret_cast<const size_t*>(dd_ptrs);
+    size_t* dd_outputs = reinterpret_cast<size_t*>(dd_ptrs + ptrs_bytes);
+    size_t* dd_outputs_sizes =
+        reinterpret_cast<size_t*>(dd_ptrs + 2 * ptrs_bytes);
+    size_t* dd_outputs_indices =
+        reinterpret_cast<size_t*>(dd_ptrs + 3 * ptrs_bytes);
+
+    Tensor d_offsets_buffer_t;
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(
+                            DT_INT32,
+                            TensorShape({total_max_inputs_size +
+                                         num_nonzero_inputs * num_partitions}),
+                            &d_offsets_buffer_t));
+    int32* d_output_segment_offsets = d_offsets_buffer_t.flat<int32>().data();
+    int32* d_output_offsets =
+        d_offsets_buffer_t.flat<int32>().data() + total_max_inputs_size;
+
+    CudaLaunch(PartitionNComputeSizes<T, ComputeShard>, total_max_inputs_size,
+               0, d, nullptr, total_max_inputs_size, max_inputs_size,
+               num_partitions, modulus, d_inputs_size, dd_inputs,
+               dd_outputs_sizes, d_output_segment_offsets);
+
+    CudaLaunch(PartitionNComputeOffsets, num_nonzero_inputs, 0, d, nullptr,
+               num_nonzero_inputs, num_partitions, dd_outputs_sizes,
+               d_output_offsets);
+
+    CudaLaunch(PartitionNPopulate<T, ComputeShard>, total_max_inputs_size, 0, d,
+               nullptr, total_max_inputs_size, max_inputs_size, num_partitions,
+               modulus, d_inputs_size, dd_inputs, dd_outputs,
+               dd_outputs_indices, d_output_segment_offsets, d_output_offsets);
+
+    TensorReference ref_hd_all_outputs_sizes_t(hd_all_outputs_sizes_t);
+    TensorReference ref_h_inputs_size_t(h_inputs_size_t);
+    TensorReference ref_d_inputs_size_t(d_inputs_size_t);
+    TensorReference ref_hd_ptrs_t(hd_ptrs_t);
+    TensorReference ref_dd_ptrs_t(dd_ptrs_t);
+    TensorReference ref_d_offsets_buffer_t(d_offsets_buffer_t);
+    ctx->device()->tensorflow_gpu_device_info()->event_mgr->ThenExecute(
+        ctx->op_device_context()->stream(),
+        [range, ref_hd_all_outputs_sizes_t, ref_h_inputs_size_t,
+         ref_d_inputs_size_t, ref_hd_ptrs_t, ref_dd_ptrs_t,
+         ref_d_offsets_buffer_t]() {
+          delete range;
+          ref_hd_all_outputs_sizes_t.Unref();
+          ref_h_inputs_size_t.Unref();
+          ref_d_inputs_size_t.Unref();
+          ref_hd_ptrs_t.Unref();
+          ref_dd_ptrs_t.Unref();
+          ref_d_offsets_buffer_t.Unref();
+        });
+  }
+};
+
+template struct PartitionByDualModuloN<GPUDevice, int32,
+                                       ComputeShardOnGpuAtStageOne>;
+template struct PartitionByDualModuloN<GPUDevice, int32,
+                                       ComputeShardOnGpuAtStageTwo>;
+template struct PartitionByDualModuloN<GPUDevice, int64,
+                                       ComputeShardOnGpuAtStageOne>;
+template struct PartitionByDualModuloN<GPUDevice, int64,
+                                       ComputeShardOnGpuAtStageTwo>;
+template struct PartitionByDualModuloN<GPUDevice, uint32,
+                                       ComputeShardOnGpuAtStageOne>;
+template struct PartitionByDualModuloN<GPUDevice, uint32,
+                                       ComputeShardOnGpuAtStageTwo>;
+template struct PartitionByDualModuloN<GPUDevice, uint64,
+                                       ComputeShardOnGpuAtStageOne>;
+template struct PartitionByDualModuloN<GPUDevice, uint64,
+                                       ComputeShardOnGpuAtStageTwo>;
+
+}  // namespace functor
+}  // namespace hybridbackend
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA
+#endif  // HYBRIDBACKEND_TENSORFLOW

--- a/hybridbackend/tensorflow/ops/partition_by_dual_modulo/partition_by_dual_modulo_ops.cc
+++ b/hybridbackend/tensorflow/ops/partition_by_dual_modulo/partition_by_dual_modulo_ops.cc
@@ -1,0 +1,310 @@
+/* Copyright 2021 Alibaba Group Holding Limited. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if HYBRIDBACKEND_TENSORFLOW
+
+#include <bitset>
+
+#define EIGEN_USE_THREADS
+#if GOOGLE_CUDA
+#define EIGEN_USE_GPU
+#endif  // GOOGLE_CUDA
+
+#include <tensorflow/core/framework/op_kernel.h>
+#include <tensorflow/core/framework/register_types.h>
+#include <tensorflow/core/framework/shape_inference.h>
+#include <tensorflow/core/framework/tensor.pb.h>
+
+#include "hybridbackend/common/env.h"
+#include "hybridbackend/tensorflow/ops/partition_by_dual_modulo/functors.h"
+
+#if GOOGLE_CUDA
+#include "hybridbackend/tensorflow/common/host_functions.h"
+#endif  // GOOGLE_CUDA
+
+namespace tensorflow {
+
+using CPUDevice = Eigen::ThreadPoolDevice;
+using GPUDevice = Eigen::GpuDevice;
+
+namespace hybridbackend {
+
+REGISTER_OP("HbPartitionByDualModuloStageOne")
+    .Output("output: T")
+    .Output("sizes: int32")
+    .Output("indices: int32")
+    .Input("input: T")
+    .Attr("T: {int32, int64, uint32, uint64}")
+    .Attr("num_partitions: int >= 1")
+    .Attr("modulus: int >= 1")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      c->set_output(0, c->input(0));
+      int num_partitions;
+      TF_RETURN_IF_ERROR(c->GetAttr("num_partitions", &num_partitions));
+      c->set_output(1, c->Vector(num_partitions));
+      c->set_output(2, c->input(0));
+      return Status::OK();
+    })
+    .Doc(R"doc(
+Shuffle inputs into partitions.
+
+output: Shuffling result with same shape of input.
+sizes: Partition sizes in output.
+indices: Indices for gathering output back to input.
+input: Input vector.
+num_partitions: Number of partitions.
+modulus: modulus to calculate partition id.
+)doc");
+
+template <typename Device, typename T, typename Stage>
+class PartitionByDualModuloOp : public OpKernel {
+ public:
+  PartitionByDualModuloOp(OpKernelConstruction* ctx) : OpKernel(ctx) {
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("num_partitions", &num_partitions_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("modulus", &modulus_));
+  }
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor& input = ctx->input(0);
+
+    OP_REQUIRES(ctx, TensorShapeUtils::IsVector(input.shape()),
+                errors::InvalidArgument(
+                    "partition_by_dual_modulo expects a 1D vector."));
+
+    const int32 input_size = input.NumElements();
+    Tensor* output = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->allocate_output(0, {input_size}, &output));
+
+    Tensor* sizes = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->allocate_output(1, {num_partitions_}, &sizes));
+
+    Tensor* indices = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->allocate_output(2, {input_size}, &indices));
+
+    functor::PartitionByDualModulo<Device, T, Stage>()(
+        num_partitions_, modulus_, input, output, sizes, indices, ctx);
+  }
+
+ private:
+  int32 num_partitions_;
+  int32 modulus_;
+};
+
+#define TF_CALL_SHUFFLE_PARTITION_TYPES(m) \
+  TF_CALL_int32(m) TF_CALL_uint32(m) TF_CALL_int64(m) TF_CALL_uint64(m)
+
+#define REGISTER_SHUFFLE_PARTITION_KERNEL(TYPE)                 \
+  REGISTER_KERNEL_BUILDER(                                      \
+      Name("HbPartitionByDualModuloStageOne")                   \
+          .Device(DEVICE_CPU)                                   \
+          .TypeConstraint<TYPE>("T"),                           \
+      PartitionByDualModuloOp<CPUDevice, TYPE,                  \
+                              functor::ComputeShardAtStageOne>) \
+  REGISTER_KERNEL_BUILDER(                                      \
+      Name("HbPartitionByDualModuloStageOne")                   \
+          .Device(DEVICE_GPU)                                   \
+          .TypeConstraint<TYPE>("T"),                           \
+      PartitionByDualModuloOp<GPUDevice, TYPE,                  \
+                              functor::ComputeShardOnGpuAtStageOne>)
+TF_CALL_SHUFFLE_PARTITION_TYPES(REGISTER_SHUFFLE_PARTITION_KERNEL);
+#undef REGISTER_SHUFFLE_PARTITION_KERNEL
+
+REGISTER_OP("HbPartitionByDualModuloStageTwo")
+    .Output("output: T")
+    .Output("sizes: int32")
+    .Output("indices: int32")
+    .Input("input: T")
+    .Attr("T: {int32, int64, uint32, uint64}")
+    .Attr("num_partitions: int >= 1")
+    .Attr("modulus: int >= 1")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      c->set_output(0, c->input(0));
+      int num_partitions;
+      TF_RETURN_IF_ERROR(c->GetAttr("num_partitions", &num_partitions));
+      c->set_output(1, c->Vector(num_partitions));
+      c->set_output(2, c->input(0));
+      return Status::OK();
+    })
+    .Doc(R"doc(
+Shuffle inputs into partitions.
+
+output: Shuffling result with same shape of input.
+sizes: Partition sizes in output.
+indices: Indices for gathering output back to input.
+input: Input vector.
+num_partitions: Number of partitions.
+modulus: modulus to calculate partition id.
+)doc");
+
+#define TF_CALL_SHUFFLE_PARTITION_TYPES(m) \
+  TF_CALL_int32(m) TF_CALL_uint32(m) TF_CALL_int64(m) TF_CALL_uint64(m)
+
+#define REGISTER_SHUFFLE_PARTITION_KERNEL(TYPE)                 \
+  REGISTER_KERNEL_BUILDER(                                      \
+      Name("HbPartitionByDualModuloStageTwo")                   \
+          .Device(DEVICE_CPU)                                   \
+          .TypeConstraint<TYPE>("T"),                           \
+      PartitionByDualModuloOp<CPUDevice, TYPE,                  \
+                              functor::ComputeShardAtStageTwo>) \
+  REGISTER_KERNEL_BUILDER(                                      \
+      Name("HbPartitionByDualModuloStageTwo")                   \
+          .Device(DEVICE_GPU)                                   \
+          .TypeConstraint<TYPE>("T"),                           \
+      PartitionByDualModuloOp<GPUDevice, TYPE,                  \
+                              functor::ComputeShardOnGpuAtStageTwo>)
+TF_CALL_SHUFFLE_PARTITION_TYPES(REGISTER_SHUFFLE_PARTITION_KERNEL);
+#undef REGISTER_SHUFFLE_PARTITION_KERNEL
+
+REGISTER_OP("HbPartitionByDualModuloStageOneN")
+    .Output("outputs: N * T")
+    .Output("outputs_sizes: N * int32")
+    .Output("outputs_indices: N * int32")
+    .Input("inputs: N * T")
+    .Attr("N: int >= 1 = 1")
+    .Attr("T: {int32, int64, uint32, uint64}")
+    .Attr("num_partitions: int >= 1")
+    .Attr("modulus: int >= 1")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      int64 num_inputs;
+      TF_RETURN_IF_ERROR(c->GetAttr("N", &num_inputs));
+      int num_partitions;
+      TF_RETURN_IF_ERROR(c->GetAttr("num_partitions", &num_partitions));
+      for (int64 i = 0; i < num_inputs; ++i) {
+        c->set_output(i, c->input(i));
+        c->set_output(num_inputs + i, c->Vector(num_partitions));
+        c->set_output(2 * num_inputs + i, c->input(i));
+      }
+      return Status::OK();
+    })
+    .Doc(R"doc(
+Shuffle multiple inputs into partitions.
+
+outputs: Shuffling results with same shape of inputs.
+outputs_sizes: Partition sizes in outputs.
+outputs_indices: Indices for gathering outputs back to inputs.
+inputs: Input vectors.
+num_partitions: Number of partitions.
+modulus: modulus to calculate partition id.
+)doc");
+
+template <typename Device, typename T, typename Stage>
+class PartitionByDualModuloNOp : public OpKernel {
+ public:
+  PartitionByDualModuloNOp(OpKernelConstruction* ctx) : OpKernel(ctx) {
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("N", &num_inputs_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("num_partitions", &num_partitions_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("modulus", &modulus_));
+  }
+
+  void Compute(OpKernelContext* ctx) override {
+    OpInputList inputs;
+    OP_REQUIRES_OK(ctx, ctx->input_list("inputs", &inputs));
+
+    std::vector<Tensor> inputs_vec;
+    std::vector<Tensor*> outputs_vec;
+    std::vector<Tensor*> sizes_vec;
+    std::vector<Tensor*> indices_vec;
+
+    for (int i = 0; i < num_inputs_; ++i) {
+      const Tensor& input = inputs[i];
+      OP_REQUIRES(
+          ctx, TensorShapeUtils::IsVector(input.shape()),
+          errors::InvalidArgument(
+              "partition_by_dual_modulo_n expects 1D vector for input ", i));
+      const int32 input_size = input.NumElements();
+      inputs_vec.push_back(input);
+      Tensor* output = nullptr;
+      OP_REQUIRES_OK(ctx, ctx->allocate_output(i, {input_size}, &output));
+      outputs_vec.push_back(output);
+      Tensor* sizes = nullptr;
+      OP_REQUIRES_OK(ctx, ctx->allocate_output(num_inputs_ + i,
+                                               {num_partitions_}, &sizes));
+      sizes_vec.push_back(sizes);
+      Tensor* indices = nullptr;
+      OP_REQUIRES_OK(ctx, ctx->allocate_output(2 * num_inputs_ + i,
+                                               {input_size}, &indices));
+      indices_vec.push_back(indices);
+    }
+
+    functor::PartitionByDualModuloN<Device, T, Stage>()(
+        num_partitions_, modulus_, inputs_vec, outputs_vec, sizes_vec,
+        indices_vec, ctx);
+  }
+
+ private:
+  int32 num_inputs_;
+  int32 num_partitions_;
+  int32 modulus_;
+};
+
+#if GOOGLE_CUDA
+#define REGISTER_SHUFFLE_PARTITION_KERNEL(TYPE) \
+  REGISTER_KERNEL_BUILDER(                      \
+      Name("HbPartitionByDualModuloStageOneN")  \
+          .Device(DEVICE_GPU)                   \
+          .TypeConstraint<TYPE>("T"),           \
+      PartitionByDualModuloNOp<GPUDevice, TYPE, \
+                               functor::ComputeShardOnGpuAtStageOne>)
+TF_CALL_SHUFFLE_PARTITION_TYPES(REGISTER_SHUFFLE_PARTITION_KERNEL);
+#undef REGISTER_SHUFFLE_PARTITION_KERNEL
+#endif  // GOOGLE_CUDA
+
+REGISTER_OP("HbPartitionByDualModuloStageTwoN")
+    .Output("outputs: N * T")
+    .Output("outputs_sizes: N * int32")
+    .Output("outputs_indices: N * int32")
+    .Input("inputs: N * T")
+    .Attr("N: int >= 1 = 1")
+    .Attr("T: {int32, int64, uint32, uint64}")
+    .Attr("num_partitions: int >= 1")
+    .Attr("modulus: int >= 1")
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      int64 num_inputs;
+      TF_RETURN_IF_ERROR(c->GetAttr("N", &num_inputs));
+      int num_partitions;
+      TF_RETURN_IF_ERROR(c->GetAttr("num_partitions", &num_partitions));
+      for (int64 i = 0; i < num_inputs; ++i) {
+        c->set_output(i, c->input(i));
+        c->set_output(num_inputs + i, c->Vector(num_partitions));
+        c->set_output(2 * num_inputs + i, c->input(i));
+      }
+      return Status::OK();
+    })
+    .Doc(R"doc(
+Shuffle multiple inputs into partitions.
+
+outputs: Shuffling results with same shape of inputs.
+outputs_sizes: Partition sizes in outputs.
+outputs_indices: Indices for gathering outputs back to inputs.
+inputs: Input vectors.
+num_partitions: Number of partitions.
+modulus: modulus to calculate partition id.
+)doc");
+
+#if GOOGLE_CUDA
+#define REGISTER_SHUFFLE_PARTITION_KERNEL(TYPE) \
+  REGISTER_KERNEL_BUILDER(                      \
+      Name("HbPartitionByDualModuloStageTwoN")  \
+          .Device(DEVICE_GPU)                   \
+          .TypeConstraint<TYPE>("T"),           \
+      PartitionByDualModuloNOp<GPUDevice, TYPE, \
+                               functor::ComputeShardOnGpuAtStageTwo>)
+TF_CALL_SHUFFLE_PARTITION_TYPES(REGISTER_SHUFFLE_PARTITION_KERNEL);
+#undef REGISTER_SHUFFLE_PARTITION_KERNEL
+#endif  // GOOGLE_CUDA
+}  // namespace hybridbackend
+}  // namespace tensorflow
+
+#endif  // HYBRIDBACKEND_TENSORFLOW

--- a/hybridbackend/tensorflow/training/__init__.py
+++ b/hybridbackend/tensorflow/training/__init__.py
@@ -49,7 +49,7 @@ _ = (
   .register('grad_lazy_sync', False, env='HB_GRAD_LAZY_SYNC')
   .register('sharding', False)
   .register(
-    'use_hierarchical_embedding_lookup', True,
+    'use_hierarchical_embedding_lookup', False,
     env='HB_USE_HIERARCHICAL_EMBEDDING_LOOKUP')
   .register('batch_size', -1)
   .register('model_dir', None)


### PR DESCRIPTION
1. Implement a hierarchical embedding lookup to mitigate the communication overhead across cluster nodes.
2. Implement a `partition_by_dual_modulo` op, which is utilized in the hierarchical embedding lookup.
3. Implement auto-packing of `floormod_shuffle` op and auto-packing of `partition_by_dual_modulo` op.

Embedding lookup benchmark (using 8days Taobao dataset) results on a 2x8xA100 testbed (intra-node communication via nvswitch and inter-node communication via  32Gbps Ethernet.)
- bs=5120,  hierarchical embedding lookup improves throughput by 2.78x
- bs=10240, hierarchical embedding lookup improves throughput by 5.16x