### PR TITLE
[DIST] Using empty data at the end of SyncReplicasDataset.

### DIFF
--- a/hybridbackend/tensorflow/data/__init__.py
+++ b/hybridbackend/tensorflow/data/__init__.py
@@ -42,4 +42,4 @@ from hybridbackend.tensorflow.framework.context import Context as _ctx
 _ = (
   _ctx.get().options
   .register('data_batch_count', 1)
-  .register('data_sync_drop_remainder', True))
+  .register('data_sync_drop_remainder', False))

--- a/hybridbackend/tensorflow/data/iterators.py
+++ b/hybridbackend/tensorflow/data/iterators.py
@@ -30,7 +30,7 @@ from tensorflow.python.ops import math_ops
 from tensorflow.python.training import session_run_hook
 
 from hybridbackend.tensorflow.data.prefetch.iterator import Iterator
-from hybridbackend.tensorflow.data.sync.dataset import _SyncReplicasDataset
+from hybridbackend.tensorflow.data.sync.dataset import SyncReplicasDataset
 from hybridbackend.tensorflow.distribute.collective import Collective
 from hybridbackend.tensorflow.distribute.ops import CollectiveOps
 from hybridbackend.tensorflow.framework.context import Context
@@ -83,15 +83,15 @@ class IteratorRewriting(GraphRewriting):
     r'''Wraps make_*_iterator.
     '''
     def wrapped_make_iterator(ds, *args, **kwargs):
-      if isinstance(ds, _SyncReplicasDataset):
+      if isinstance(ds, SyncReplicasDataset):
         return fn(ds, *args, **kwargs)
       if isinstance(ds, dataset_ops.DatasetV1Adapter):
-        if isinstance(ds._dataset, _SyncReplicasDataset):  # pylint: disable=protected-access
+        if isinstance(ds._dataset, SyncReplicasDataset):  # pylint: disable=protected-access
           return fn(ds, *args, **kwargs)
       with ops.device('/cpu:0'):
         options = Context.get().options
         if options.mode == ModeKeys.TRAIN:
-          return fn(_SyncReplicasDataset(ds), *args, **kwargs)
+          return fn(SyncReplicasDataset(ds), *args, **kwargs)
         if options.mode == ModeKeys.EVAL:
           return fn(ds.repeat(), *args, **kwargs)
         return fn(ds, *args, **kwargs)

--- a/hybridbackend/tensorflow/data/sync/dataset_v1.py
+++ b/hybridbackend/tensorflow/data/sync/dataset_v1.py
@@ -25,26 +25,32 @@ from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_shape
+from tensorflow.python.framework import tensor_spec
 
 from hybridbackend.tensorflow.common import oplib as _ops
 from hybridbackend.tensorflow.data.sync.hook import SyncReplicasDatasetHook
+from hybridbackend.tensorflow.data.sync.utils import denormalize
+from hybridbackend.tensorflow.data.sync.utils import normalize
 
 
 class _SyncReplicasDatasetV1(dataset_ops.Dataset):
   r'''A dataset that syncs data between replicas.
   '''
-  def __init__(self, input_dataset):
+  def __init__(self, input_dataset, output_kinds):
     r'''Create a `_SyncReplicasDatasetV1`.
 
     Args:
       input_dataset: A `dataset` to be wrapped to verify its last element.
+      output_kinds: A list of int to specify the type of tensors.
     '''
     self._input_dataset = input_dataset
+    self._output_kinds = output_kinds
     super().__init__()
 
   def _as_variant_tensor(self):
     return _ops.hb_sync_replicas_dataset(
-      self._input_dataset._as_variant_tensor())  # pylint: disable=protected-access
+      self._input_dataset._as_variant_tensor(),  # pylint: disable=protected-access
+      output_kinds=self._output_kinds)  # pylint: disable=protected-access
 
   def _inputs(self):
     return [self._input_dataset]
@@ -81,16 +87,21 @@ class SyncReplicasDatasetV1(dataset_ops.Dataset):
   def sync(cls, features=None):
     return SyncReplicasDatasetHook.sync_all_instances(features)
 
-  def __init__(self, input_dataset, world, rank):
+  def __init__(self, input_dataset, world=None, rank=None):
     r'''Create a `SyncReplicasDatasetV1`.
 
     Args:
       input_dataset: A `dataset` to be wrapped to verify its last element.
     '''
     self._input_dataset = input_dataset
-    self._hook = SyncReplicasDatasetHook(world, rank)
-    self._impl = _SyncReplicasDatasetV1(self._input_dataset).map(
-      self._hook.register)
+    self._hook = SyncReplicasDatasetHook(world, rank)\
+      if (world is not None and rank is not None) else None
+
+    normalized_dataset, normalized_kinds, kinds = normalize(input_dataset)
+    sync_replicas_dataset = _SyncReplicasDatasetV1(
+      normalized_dataset, normalized_kinds)
+    self._impl = denormalize(
+      sync_replicas_dataset, self.element_spec, kinds, hook=self._hook)
     super().__init__()
 
   def _as_variant_tensor(self):
@@ -100,13 +111,26 @@ class SyncReplicasDatasetV1(dataset_ops.Dataset):
     return [self._input_dataset]
 
   @property
+  def element_spec(self):
+    if self._hook is None:
+      return tensor_spec.TensorSpec(shape=[], dtype=dtypes.int32), \
+        self._input_dataset.element_spec
+    return self._input_dataset.element_spec
+
+  @property
   def output_shapes(self):
+    if self._hook is None:
+      return tensor_shape.TensorShape([]), self._input_dataset.output_shapes
     return self._input_dataset.output_shapes
 
   @property
   def output_types(self):
+    if self._hook is None:
+      return dtypes.int32, self._input_dataset.output_types
     return self._input_dataset.output_types
 
   @property
   def output_classes(self):
+    if self._hook is None:
+      return ops.Tensor, self._input_dataset.output_classes
     return self._input_dataset.output_classes

--- a/hybridbackend/tensorflow/data/sync/dataset_v2.py
+++ b/hybridbackend/tensorflow/data/sync/dataset_v2.py
@@ -27,22 +27,27 @@ from tensorflow.python.framework import tensor_spec
 
 from hybridbackend.tensorflow.common import oplib as _ops
 from hybridbackend.tensorflow.data.sync.hook import SyncReplicasDatasetHook
+from hybridbackend.tensorflow.data.sync.utils import denormalize
+from hybridbackend.tensorflow.data.sync.utils import normalize
 
 
 class _SyncReplicasDatasetV2(dataset_ops.DatasetV2):
   r'''A dataset that syncs data between replicas.
   '''
-  def __init__(self, input_dataset):
+  def __init__(self, input_dataset, output_kinds):
     r'''Create a `_SyncReplicasDatasetV2`.
 
     Args:
       input_dataset: A `dataset` to be wrapped to verify its last element.
+      output_kinds: A list of int to specify the type of tensors.
     '''
     self._input_dataset = input_dataset
     self._should_stop_spec = tensor_spec.TensorSpec(
       shape=[], dtype=dtypes.int32)
+    self._output_kinds = output_kinds
     variant_tensor = _ops.hb_sync_replicas_dataset(
-      self._input_dataset._variant_tensor)  # pylint: disable=protected-access
+      self._input_dataset._variant_tensor,
+      output_kinds=output_kinds)
     super().__init__(variant_tensor)
 
   def _inputs(self):
@@ -72,16 +77,20 @@ class SyncReplicasDatasetV2(dataset_ops.DatasetV2):
   def sync(cls, features=None):
     return SyncReplicasDatasetHook.sync_all_instances(features)
 
-  def __init__(self, input_dataset, world, rank):
+  def __init__(self, input_dataset, world=None, rank=None):
     r'''Create a `SyncReplicasDatasetV2`.
 
     Args:
       input_dataset: A `dataset` to be wrapped to verify its last element.
     '''
     self._input_dataset = input_dataset
-    self._hook = SyncReplicasDatasetHook(world, rank)
-    self._impl = _SyncReplicasDatasetV2(self._input_dataset).map(
-      self._hook.register)
+    self._hook = SyncReplicasDatasetHook(world, rank)\
+      if (world is not None and rank is not None) else None
+    normalized_dataset, normalized_kinds, kinds = normalize(input_dataset)
+    sync_replicas_dataset = _SyncReplicasDatasetV2(
+      normalized_dataset, normalized_kinds)
+    self._impl = denormalize(
+      sync_replicas_dataset, self.element_spec, kinds, hook=self._hook)
     super().__init__(self._impl._variant_tensor)  # pylint: disable=protected-access
 
   def _inputs(self):
@@ -89,4 +98,7 @@ class SyncReplicasDatasetV2(dataset_ops.DatasetV2):
 
   @property
   def element_spec(self):
-    return self._input_dataset.element_spec  # pylint: disable=protected-access
+    if self._hook is None:
+      return tensor_spec.TensorSpec(shape=[], dtype=dtypes.int32), \
+        self._input_dataset.element_spec  # pylint: disable=protected-access
+    return self._input_dataset.element_spec

--- a/hybridbackend/tensorflow/data/sync/utils.py
+++ b/hybridbackend/tensorflow/data/sync/utils.py
@@ -1,0 +1,58 @@
+# Copyright 2021 Alibaba Group Holding Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+r'''SyncReplicasDataset that reports the existence of next element.
+
+This class is compatible with Tensorflow 1.12.
+'''
+
+from tensorflow.python.framework import sparse_tensor
+from tensorflow.python.framework import tensor_spec
+from tensorflow.python.util import nest
+
+from hybridbackend.tensorflow.framework.ops import TensorKinds
+
+
+def normalize(input_dataset):
+  r'''flattent to normalize tensors within the input_dataset.
+  '''
+  flattened_specs = nest.flatten(input_dataset.element_spec)
+  flattened_kinds = []
+  for spec in flattened_specs:
+    if isinstance(spec, tensor_spec.TensorSpec):
+      flattened_kinds.append(TensorKinds.VALUES)
+    elif isinstance(spec, sparse_tensor.SparseTensorSpec):
+      flattened_kinds.append(
+        sparse_tensor.SparseTensorValue(
+          TensorKinds.INDICES, TensorKinds.VALUES, TensorKinds.DENSE_SHAPE))
+    else:
+      raise ValueError(
+        'SyncReplicasDataset cannot support input datasets with outputs '
+        'other than tensors or sparse tensors')
+  return input_dataset.map(TensorKinds.normalize),\
+    nest.flatten(flattened_kinds), flattened_kinds
+
+
+def denormalize(input_dataset, element_spec, kinds, hook=None):
+  r'''denormalize all tensors returned by input_dataset.
+  '''
+  if hook is None:
+    return input_dataset.map(
+      lambda *args: TensorKinds.denormalize(
+        element_spec, [TensorKinds.VALUES] + kinds, args))
+  input_dataset = input_dataset.map(hook.register)
+  return input_dataset.map(
+    lambda *args: TensorKinds.denormalize(
+      element_spec, kinds, args))

--- a/hybridbackend/tensorflow/data/tests/sync_replicas_dataset_test.py
+++ b/hybridbackend/tensorflow/data/tests/sync_replicas_dataset_test.py
@@ -94,7 +94,9 @@ class DetectEndTest(unittest.TestCase):
 
   def test_parallel(self):
     results = hbtest.Spawn(2)(_test_distributed)
-    np.testing.assert_equal(results[0], results[1])
+    np.testing.assert_equal(results[0], [])
+    np.testing.assert_equal(
+      results[1], [140, 141, 142, 143, 144, 145, 146, 147, 148, 149])
 
 
 if __name__ == '__main__':

--- a/hybridbackend/tensorflow/framework/ops.py
+++ b/hybridbackend/tensorflow/framework/ops.py
@@ -230,6 +230,7 @@ class TensorKinds(object):  # pylint: disable=useless-object-inheritance
   def denormalize(cls, structure, flatten_structure, tensors):
     r'''Denormalize structure from list of tensors.
     '''
+    tensors = nest.flatten(tensors)
     flattened_values = nest.pack_sequence_as(flatten_structure, tensors)
     flattened_tensors = []
     for v in flattened_values:


### PR DESCRIPTION
1. set `data_sync_drop_remainder=False` by defaults.
2. Use empty data when any of the workers reaches the end of training data in SyncReplicasDataset. (close #121)