### PR TITLE
fix pyarrow error

### DIFF
--- a/docs/tutorial/ranking/taobao/data/prep_3_merge.py
+++ b/docs/tutorial/ranking/taobao/data/prep_3_merge.py
@@ -63,7 +63,8 @@ def _clip_clicks(row, behavior_log_cols, duration):
       elif ts >= max_ts:
         end_idx -= 1
     for col in cols:
-      row[col] = row[col][begin_idx: end_idx]
+      tmp = row[col][begin_idx: end_idx]
+      row[col] = tmp.tolist() if isinstance(tmp, np.ndarray) else tmp
   return row
 
 


### PR DESCRIPTION
convert both normal values and default value  to same type to avoid error below:
```
pyarrow.lib.ArrowInvalid: ('Can only convert 1-dimensional array values', 'Conversion failed for column user_buy_category_list with type object')
```